### PR TITLE
Fix borders on buttons from being clipped

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -438,6 +438,9 @@ table.tiny-button td,
 table.small-button td,
 table.medium-button td,
 table.large-button td {
+  box-sizing:border-box;
+  -moz-box-sizing:border-box;
+  -webkit-box-sizing:border-box;
   display: block;
   width: auto !important;
   text-align: center;


### PR DESCRIPTION
Set the box sizing on buttons to stop the border from making the element larger then 100% when on small devices. 
References #63
